### PR TITLE
Rationalize the Owned/Linked classes

### DIFF
--- a/deployment/deploy/DeploymentEngine.cpp
+++ b/deployment/deploy/DeploymentEngine.cpp
@@ -142,7 +142,7 @@ int CDeploymentEngine::getInstallFileCount()
         StringBuffer s;
         for (CInstallFileList::const_iterator it=files.begin(); it!=files.end(); ++it)
         {
-            const StlLinked<CInstallFile>& f = *it;
+            const Linked<CInstallFile>& f = *it;
             if (!isMethodTrackable(f->getMethod().c_str()) || startsWith(f->getMethod().c_str(),"xsl"))
                 s.append(f->getMethod().c_str()).append(": ").append(f->getSrcPath().c_str())
                 .append(" --> ").append(f->getDestPath().c_str()).newline();
@@ -159,7 +159,7 @@ int CDeploymentEngine::getInstallFileCount()
     int count = 0, xslcount = 0, total = 0;
     for (CInstallFileList::const_iterator it=files.begin(); it!=files.end(); ++it)
     {
-      const StlLinked<CInstallFile>& f = *it;
+      const Linked<CInstallFile>& f = *it;
       const char* method = f->getMethod().c_str();
       if (strieq(method,"copy"))
         count++;
@@ -208,7 +208,7 @@ offset_t CDeploymentEngine::getInstallFileSize()
 
     for (CInstallFileList::const_iterator it=files.begin(); it!=files.end(); ++it)
     {
-      const StlLinked<CInstallFile>& f = *it;
+      const Linked<CInstallFile>& f = *it;
       const char* method = f->getMethod().c_str();
       if (strieq(method,"copy"))
         fileSize += f->getSrcSize();
@@ -2348,7 +2348,7 @@ void CDeploymentEngine::addDeploymentFile(StringBuffer &ret, const char *in, IXs
     if (len > 5)
         pInstallFile->setParams(tokens.item(5));
     
-    s_dynamicFileList.push_back(StlLinkedFilePtr(pInstallFile.get()));
+    s_dynamicFileList.push_back(LinkedFilePtr(pInstallFile.get()));
 }
 
 
@@ -2595,7 +2595,7 @@ void CDeploymentEngine::siteCertificate(IPropertyTree& process, const char *inst
         
         //add this file copy operation to our todo list
         Owned<CInstallFile> pInstallFile = new CInstallFile("copy", tempfile, pszCertFile);
-        s_dynamicFileList.push_back(StlLinkedFilePtr(pInstallFile.get()));
+        s_dynamicFileList.push_back(LinkedFilePtr(pInstallFile.get()));
         
         //Now handle private key ------------------------------
         
@@ -2612,7 +2612,7 @@ void CDeploymentEngine::siteCertificate(IPropertyTree& process, const char *inst
         
         //add this file copy operation to our todo list
         Owned<CInstallFile> pInstallFile2 = new CInstallFile("copy", tempfile, pszPrivFile);
-        s_dynamicFileList.push_back(StlLinkedFilePtr(pInstallFile2.get()));
+        s_dynamicFileList.push_back(LinkedFilePtr(pInstallFile2.get()));
     }
 }
 

--- a/deployment/deploy/DeploymentEngine.hpp
+++ b/deployment/deploy/DeploymentEngine.hpp
@@ -122,9 +122,9 @@ bool operator()(const string& _X, const string& _Y) const
     {return stricmp(_X.c_str(), _Y.c_str()) < 0; }
 };
 
-typedef StlLinked<CInstallFile> StlLinkedFilePtr;
+typedef Linked<CInstallFile> LinkedFilePtr;
 
-class CInstallFileMap : public std::multimap<std::string, StlLinkedFilePtr, iless_string> 
+class CInstallFileMap : public std::multimap<std::string, LinkedFilePtr, iless_string>
 {
 public:
    CInstallFileMap()
@@ -146,7 +146,7 @@ private:
    IDeploymentEngine* m_pDepEngine;
 };
 
-typedef vector<StlLinked<CInstallFile> > CInstallFileList;
+typedef vector<Linked<CInstallFile> > CInstallFileList;
 
 struct CInstallFiles 
 {
@@ -173,7 +173,7 @@ public:
    }
    CInstallFile* addInstallFile(const char* method, const char* srcPath, const char* destPath, bool bCacheable, const char* params)
    {
-        StlLinkedFilePtr pFile = new CInstallFile(method, srcPath, destPath, bCacheable);
+        LinkedFilePtr pFile = new CInstallFile(method, srcPath, destPath, bCacheable);
         
         if (params)
             pFile->setParams(params);

--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -2908,7 +2908,7 @@ IHqlExpression * queryPropertyChild(ITypeInfo * type, _ATOM search, unsigned idx
 
 // Functions for extracting and preserving attribute information on types and fields.
 
-void cloneFieldModifier(Owned<ITypeInfo> & type, ITypeInfo * donorType, _ATOM attr)
+void cloneFieldModifier(Shared<ITypeInfo> & type, ITypeInfo * donorType, _ATOM attr)
 {
     IHqlExpression * match = queryProperty(donorType, attr);
     if (!match)

--- a/ecl/hql/hqlerror.cpp
+++ b/ecl/hql/hqlerror.cpp
@@ -271,7 +271,7 @@ protected:
 
 //---------------------------------------------------------------------------------------------------------------------
 
-void checkEclVersionCompatible(Owned<IErrorReceiver> & errors, const char * eclVersion)
+void checkEclVersionCompatible(Shared<IErrorReceiver> & errors, const char * eclVersion)
 {
     if (eclVersion)
     {

--- a/ecl/hql/hqlerror.hpp
+++ b/ecl/hql/hqlerror.hpp
@@ -113,7 +113,7 @@ void HQL_API reportError(IErrorReceiver * errors, int errNo, const ECLlocation &
 void HQL_API expandReportError(IErrorReceiver * errors, IECLError* error);
 extern HQL_API IErrorReceiver *createFileErrorReceiver(FILE *f);
 
-extern HQL_API void checkEclVersionCompatible(Owned<IErrorReceiver> & errors, const char * eclVersion);
+extern HQL_API void checkEclVersionCompatible(Shared<IErrorReceiver> & errors, const char * eclVersion);
 
 
 #endif // _HQLERROR_HPP_

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -12188,7 +12188,7 @@ static IHqlExpression * doAttachWorkflowOwn(IHqlExpression * value, IHqlExpressi
 }
 
 
-void processSectionPseudoWorkflow(OwnedHqlExpr & expr, IHqlExpression * workflow, const HqlExprCopyArray * allActiveParameters)
+void processSectionPseudoWorkflow(SharedHqlExpr & expr, IHqlExpression * workflow, const HqlExprCopyArray * allActiveParameters)
 {
     //Section attributes are implemented by adding a sectionAnnotation to all datasets within a section that aren't 
     //included in the list of active parameters, or the datasets provided as parameters to the section
@@ -12214,7 +12214,7 @@ void processSectionPseudoWorkflow(OwnedHqlExpr & expr, IHqlExpression * workflow
 }
 
 
-static IHqlExpression * processPseudoWorkflow(OwnedHqlExpr & expr, HqlExprArray & meta, IHqlExpression * workflow, const HqlExprCopyArray * allActiveParameters)
+static IHqlExpression * processPseudoWorkflow(SharedHqlExpr & expr, HqlExprArray & meta, IHqlExpression * workflow, const HqlExprCopyArray * allActiveParameters)
 {
     switch (workflow->getOperator())
     {
@@ -14841,7 +14841,7 @@ ITypeInfo * getTypedefType(IHqlExpression * expr)
     return makeOriginalModifier(expr->getType(), LINK(expr)); 
 }
 
-void extendAdd(OwnedHqlExpr & value, IHqlExpression * expr)
+void extendAdd(SharedHqlExpr & value, IHqlExpression * expr)
 {
     if (value)
         value.setown(createValue(no_add, value->getType(), LINK(value), LINK(expr)));

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1177,6 +1177,7 @@ interface IHqlNamedAnnotation : public IHqlAnnotation
 
 
 typedef Linked<IHqlExpression> HqlExprAttr;
+typedef Shared<IHqlExpression> SharedHqlExpr;
 typedef Linked<IHqlExpression> LinkedHqlExpr;
 typedef Owned<IHqlExpression>  OwnedHqlExpr;
 
@@ -1734,7 +1735,7 @@ extern HQL_API ITypeInfo * getTypedefType(IHqlExpression * expr);
 
 extern HQL_API ITypeInfo * getPromotedECLType(ITypeInfo * lType, ITypeInfo * rType);
 extern HQL_API ITypeInfo * getPromotedECLCompareType(ITypeInfo * lType, ITypeInfo * rType);
-extern HQL_API void extendAdd(OwnedHqlExpr & value, IHqlExpression * expr);
+extern HQL_API void extendAdd(SharedHqlExpr & value, IHqlExpression * expr);
 inline bool isOmitted(IHqlExpression * actual) { return !actual || actual->getOperator() == no_omitted; }
 
 extern HQL_API IFileContents * createFileContentsFromText(unsigned len, const char * text, ISourcePath * sourcePath);

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -476,7 +476,7 @@ public:
     _ATOM ensureCommonLocale(attribute &a, attribute &b);
     void ensureUnicodeLocale(attribute & a, char const * locale);
     void ensureType(attribute &atr, ITypeInfo * type);
-    void inheritRecordMaxLength(IHqlExpression * dataset, OwnedHqlExpr & record);
+    void inheritRecordMaxLength(IHqlExpression * dataset, SharedHqlExpr & record);
 
     void normalizeExpression(attribute & expr);
     void normalizeExpression(attribute & expr, type_t expectedType, bool isConstant);
@@ -589,7 +589,7 @@ public:
     void checkAssignedNormalizeTransform(IHqlExpression * record, const attribute &errpos);
     void doCheckAssignedNormalizeTransform(HqlExprArray * assigns, IHqlExpression* select, IHqlExpression* targetSelect, IHqlExpression * cur, const attribute& errpos, bool & modified);
 
-    bool checkValidBaseModule(const attribute & attr, OwnedHqlExpr & expr);
+    bool checkValidBaseModule(const attribute & attr, SharedHqlExpr & expr);
     IHqlExpression * implementInterfaceFromModule(attribute & iAttr, attribute & mAttr, IHqlExpression * flags);
     IHqlExpression * implementInterfaceFromModule(const attribute & modpos, const attribute & ipos, IHqlExpression * implementModule, IHqlExpression * projectInterface, IHqlExpression * flags);
 
@@ -950,12 +950,12 @@ protected:
     IHqlExpression *queryCurrentTransformRecord();
     IHqlExpression* queryFieldMap(IHqlExpression* expr);
     IHqlExpression* bindFieldMap(IHqlExpression*, IHqlExpression*);
-    void applyPayloadAttribute(const attribute & errpos, IHqlExpression * record, OwnedHqlExpr & extra);
-    void extractRecordFromExtra(OwnedHqlExpr & record, OwnedHqlExpr & extra);
+    void applyPayloadAttribute(const attribute & errpos, IHqlExpression * record, SharedHqlExpr & extra);
+    void extractRecordFromExtra(SharedHqlExpr & record, SharedHqlExpr & extra);
     void transferOptions(attribute & filenameAttr, attribute & optionsAttr);
-    IHqlExpression * extractTransformFromExtra(OwnedHqlExpr & extra);
+    IHqlExpression * extractTransformFromExtra(SharedHqlExpr & extra);
     void expandPayload(HqlExprArray & fields, IHqlExpression * payload, IHqlSimpleScope * scope, ITypeInfo * & lastFieldType, const attribute & errpos);
-    void modifyIndexPayloadRecord(OwnedHqlExpr & record, OwnedHqlExpr & payload, OwnedHqlExpr & extra, const attribute & errpos);
+    void modifyIndexPayloadRecord(SharedHqlExpr & record, SharedHqlExpr & payload, SharedHqlExpr & extra, const attribute & errpos);
 
     bool haveAssignedToChildren(IHqlExpression * select);
     void checkPattern(attribute & pattern, bool isCompound);
@@ -1129,7 +1129,7 @@ class HqlLex
         void declareUniqueName(const char* name, const char * pattern);
         void checkNextLoop(const YYSTYPE & errpos, bool first,int startLine,int startCol);
 
-        bool getDefinedParameter(StringBuffer &curParam, YYSTYPE & returnToken, const char* for_what, OwnedHqlExpr & resolved);
+        bool getDefinedParameter(StringBuffer &curParam, YYSTYPE & returnToken, const char* for_what, SharedHqlExpr & resolved);
 
         bool checkUnicodeLiteral(char const * str, unsigned length, unsigned & ep, StringBuffer & msg);
 

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -2835,7 +2835,7 @@ IHqlExpression * HqlGram::getSelfDotExpr(const attribute & errpos)
     return LINK(querySelfReference());
 }
 
-bool HqlGram::checkValidBaseModule(const attribute & attr, OwnedHqlExpr & expr)
+bool HqlGram::checkValidBaseModule(const attribute & attr, SharedHqlExpr & expr)
 {
     node_operator op = expr->getOperator();
     if ((op == no_virtualscope) || (op == no_libraryscopeinstance) || (op == no_param))
@@ -7062,7 +7062,7 @@ IHqlExpression * HqlGram::createIndexFromRecord(IHqlExpression * record, IHqlExp
 }
 
 
-void HqlGram::inheritRecordMaxLength(IHqlExpression * dataset, OwnedHqlExpr & record)
+void HqlGram::inheritRecordMaxLength(IHqlExpression * dataset, SharedHqlExpr & record)
 {
     IHqlExpression * maxLength = queryRecordProperty(dataset->queryRecord(), maxLengthAtom);
 //  if (maxLength && isVariableSizeRecord(record) && !queryRecordProperty(record, maxLengthAtom))
@@ -7709,7 +7709,7 @@ void HqlGram::expandPayload(HqlExprArray & fields, IHqlExpression * payload, IHq
     }
 }
 
-void HqlGram::modifyIndexPayloadRecord(OwnedHqlExpr & record, OwnedHqlExpr & payload, OwnedHqlExpr & extra, const attribute & errpos)
+void HqlGram::modifyIndexPayloadRecord(SharedHqlExpr & record, SharedHqlExpr & payload, SharedHqlExpr & extra, const attribute & errpos)
 {
     IHqlSimpleScope * scope = record->querySimpleScope();
 
@@ -7763,7 +7763,7 @@ void HqlGram::modifyIndexPayloadRecord(OwnedHqlExpr & record, OwnedHqlExpr & pay
     record.setown(createRecord(fields));
 }
 
-void HqlGram::extractRecordFromExtra(OwnedHqlExpr & record, OwnedHqlExpr & extra)
+void HqlGram::extractRecordFromExtra(SharedHqlExpr & record, SharedHqlExpr & extra)
 {
     while (record->getOperator() == no_comma)
     {
@@ -7788,7 +7788,7 @@ void HqlGram::transferOptions(attribute & filenameAttr, attribute & optionsAttr)
 }
 
 
-IHqlExpression * HqlGram::extractTransformFromExtra(OwnedHqlExpr & extra)
+IHqlExpression * HqlGram::extractTransformFromExtra(SharedHqlExpr & extra)
 {
     IHqlExpression * ret = NULL;
     if (extra)
@@ -7806,7 +7806,7 @@ IHqlExpression * HqlGram::extractTransformFromExtra(OwnedHqlExpr & extra)
 }
             
 
-void HqlGram::applyPayloadAttribute(const attribute & errpos, IHqlExpression * record, OwnedHqlExpr & extra)
+void HqlGram::applyPayloadAttribute(const attribute & errpos, IHqlExpression * record, SharedHqlExpr & extra)
 {
     IHqlExpression * payload = queryPropertyInList(payloadAtom, extra);
     if (payload)

--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -1134,7 +1134,7 @@ IHqlExpression * CTreeOptimizer::queryPromotedFilter(IHqlExpression * expr, node
 
 
 
-bool CTreeOptimizer::extractSingleFieldTempTable(IHqlExpression * expr, OwnedHqlExpr & retField, OwnedHqlExpr & retValues)
+bool CTreeOptimizer::extractSingleFieldTempTable(IHqlExpression * expr, SharedHqlExpr & retField, SharedHqlExpr & retValues)
 {
     IHqlExpression * record = expr->queryRecord();
     IHqlExpression * field = NULL;

--- a/ecl/hql/hqlopt.ipp
+++ b/ecl/hql/hqlopt.ipp
@@ -115,7 +115,7 @@ protected:
     void recursiveDecChildUsage(IHqlExpression * expr);
     IHqlExpression * inheritUsage(IHqlExpression * newExpr, IHqlExpression * oldExpr);
 
-    bool extractSingleFieldTempTable(IHqlExpression * expr, OwnedHqlExpr & retField, OwnedHqlExpr & retValues);
+    bool extractSingleFieldTempTable(IHqlExpression * expr, SharedHqlExpr & retField, SharedHqlExpr & retValues);
 
     IHqlExpression * optimizeAggregateCompound(IHqlExpression * transformed);
     IHqlExpression * optimizeAggregateUnsharedDataset(IHqlExpression * expr, bool isSimpleCount);

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -1563,7 +1563,7 @@ void HqlLex::doPreprocessorLookup(const YYSTYPE & errpos, bool stringify, int ex
 
 
 //Read the text of a parameter, but also have a good guess at whether it is defined.
-bool HqlLex::getDefinedParameter(StringBuffer &curParam, YYSTYPE & returnToken, const char* for_what, OwnedHqlExpr & resolved)
+bool HqlLex::getDefinedParameter(StringBuffer &curParam, YYSTYPE & returnToken, const char* for_what, SharedHqlExpr & resolved)
 {
     enum { StateStart, StateDot, StateSelectId, StateFailed } state = StateStart;
     unsigned parenDepth = 1;

--- a/ecl/hql/hqlthql.cpp
+++ b/ecl/hql/hqlthql.cpp
@@ -546,7 +546,7 @@ void HqltHql::childrenToECL(IHqlExpression *expr, StringBuffer &s, bool inType, 
     }
 }
 
-void splitPayload(OwnedHqlExpr & keyed, OwnedHqlExpr & payload, IHqlExpression * expr, unsigned payloadFields)
+void splitPayload(SharedHqlExpr & keyed, SharedHqlExpr & payload, IHqlExpression * expr, unsigned payloadFields)
 {
     unsigned numFields = 0;
     ForEachChild(i, expr)

--- a/ecl/hql/hqltrans.ipp
+++ b/ecl/hql/hqltrans.ipp
@@ -466,7 +466,7 @@ protected:
     virtual IHqlExpression * queryAlreadyTransformedSelector(IHqlExpression * expr);
     virtual IHqlExpression * transformSelector(IHqlExpression * expr);
 
-    inline void updateOrphanedSelectors(OwnedHqlExpr & transformed, IHqlExpression * expr)
+    inline void updateOrphanedSelectors(SharedHqlExpr & transformed, IHqlExpression * expr)
     {
         if (expr != transformed)
             transformed.setown(doUpdateOrphanedSelectors(expr, transformed));
@@ -765,7 +765,7 @@ public:
 
     inline IHqlExpression * getValue(IHqlExpression * key)
     {
-        OwnedHqlExpr * match = map.getValue(key);
+        LinkedHqlExpr * match = map.getValue(key);
         if (match)
             return match->get();
         return NULL;

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -4137,7 +4137,7 @@ public:
     virtual void analyseExpr(IHqlExpression * expr);
     virtual IHqlExpression * createTransformed(IHqlExpression * expr);
 
-    bool split(OwnedHqlExpr & dataset, OwnedHqlExpr & attribute, IHqlExpression * expr);
+    bool split(SharedHqlExpr & dataset, SharedHqlExpr & attribute, IHqlExpression * expr);
 
 protected:
     void doAnalyseSelect(IHqlExpression * expr);
@@ -4260,7 +4260,7 @@ IHqlExpression * SplitDatasetAttributeTransformer::doTransformSelect(IHqlExpress
 
 
 
-bool SplitDatasetAttributeTransformer::split(OwnedHqlExpr & dataset, OwnedHqlExpr & attribute, IHqlExpression * expr)
+bool SplitDatasetAttributeTransformer::split(SharedHqlExpr & dataset, SharedHqlExpr & attribute, IHqlExpression * expr)
 {
     analyseExpr(expr);
 
@@ -4354,7 +4354,7 @@ bool SplitDatasetAttributeTransformer::split(OwnedHqlExpr & dataset, OwnedHqlExp
     return true;
 }
 
-static bool splitDatasetAttribute(OwnedHqlExpr & dataset, OwnedHqlExpr & attribute, IHqlExpression * expr)
+static bool splitDatasetAttribute(SharedHqlExpr & dataset, SharedHqlExpr & attribute, IHqlExpression * expr)
 {
 #if 0
     //The following code works.  However I think it has the side-effect of modifying expressions so that they are no longer
@@ -4451,7 +4451,7 @@ static bool splitDatasetAttribute(OwnedHqlExpr & dataset, OwnedHqlExpr & attribu
 }
 
 
-static bool splitSetResultValue(OwnedHqlExpr & dataset, OwnedHqlExpr & attribute, IHqlExpression * value)
+static bool splitSetResultValue(SharedHqlExpr & dataset, SharedHqlExpr & attribute, IHqlExpression * value)
 {
     if (value->isDataset())
         return false;
@@ -6707,7 +6707,7 @@ void extractXmlName(StringBuffer & name, StringBuffer * itemName, StringBuffer *
 }
 
 
-void extractXmlName(OwnedHqlExpr & name, OwnedHqlExpr * itemName, OwnedHqlExpr * valueName, IHqlExpression * field, const char * defaultItemName, bool reading)
+void extractXmlName(SharedHqlExpr & name, OwnedHqlExpr * itemName, OwnedHqlExpr * valueName, IHqlExpression * field, const char * defaultItemName, bool reading)
 {
     StringBuffer nameText, itemNameText, valueNameText;
 

--- a/ecl/hql/hqlutil.hpp
+++ b/ecl/hql/hqlutil.hpp
@@ -170,17 +170,17 @@ extern HQL_API IHqlExpression * queryUncastExpr(IHqlExpression * expr);
 extern HQL_API bool areConstant(const HqlExprArray & args);
 
 
-inline void extendConditionOwn(OwnedHqlExpr & cond, node_operator op, IHqlExpression * r)
+inline void extendConditionOwn(SharedHqlExpr & cond, node_operator op, IHqlExpression * r)
 {
     cond.setown(extendConditionOwn(op, cond.getClear(), r));
 }
 
-inline void extendAndCondition(OwnedHqlExpr & cond, IHqlExpression * r)
+inline void extendAndCondition(SharedHqlExpr & cond, IHqlExpression * r)
 {
     cond.setown(extendConditionOwn(no_and, cond.getClear(), LINK(r)));
 }
 
-inline void extendOrCondition(OwnedHqlExpr & cond, IHqlExpression * r)
+inline void extendOrCondition(SharedHqlExpr & cond, IHqlExpression * r)
 {
     cond.setown(extendConditionOwn(no_or, cond.getClear(), LINK(r)));
 }
@@ -609,7 +609,7 @@ extern HQL_API bool createMangledFunctionName(StringBuffer & name, IHqlExpressio
 extern HQL_API bool createMangledFunctionName(StringBuffer & mangled, IHqlExpression * funcdef, CompilerType compiler);
 
 extern HQL_API void extractXmlName(StringBuffer & name, StringBuffer * itemName, StringBuffer * valueName, IHqlExpression * field, const char * defaultItemName, bool reading);
-extern HQL_API void extractXmlName(OwnedHqlExpr & name, OwnedHqlExpr * itemName, OwnedHqlExpr * valueName, IHqlExpression * field, const char * defaultItemName, bool reading);
+extern HQL_API void extractXmlName(SharedHqlExpr & name, OwnedHqlExpr * itemName, OwnedHqlExpr * valueName, IHqlExpression * field, const char * defaultItemName, bool reading);
 extern HQL_API void getRecordXmlSchema(StringBuffer & result, IHqlExpression * record, bool useXPath);
 
 extern HQL_API IHqlExpression * querySimplifyInExpr(IHqlExpression * expr);

--- a/ecl/hqlcpp/hqlckey.cpp
+++ b/ecl/hqlcpp/hqlckey.cpp
@@ -264,8 +264,8 @@ protected:
     IHqlExpression * expandDatasetReferences(IHqlExpression * expr, IHqlExpression * ds);
     IHqlExpression * optimizeTransfer(HqlExprArray & fields, HqlExprArray & values, IHqlExpression * expr, IHqlExpression * leftSelector);
     void optimizeExtractJoinFields();
-    void optimizeTransfer(OwnedHqlExpr & targetDataset, OwnedHqlExpr & targetTransform, OwnedHqlExpr & keyedFilter, OwnedHqlExpr * extraFilter);
-    void splitFilter(IHqlExpression * filter, OwnedHqlExpr & keyTarget);
+    void optimizeTransfer(SharedHqlExpr & targetDataset, SharedHqlExpr & targetTransform, SharedHqlExpr & keyedFilter, OwnedHqlExpr * extraFilter);
+    void splitFilter(IHqlExpression * filter, SharedHqlExpr & keyTarget);
 
 protected:
     HqlCppTranslator & translator;
@@ -757,7 +757,7 @@ IHqlExpression * reverseOptimizeTransfer(IHqlExpression * left, IHqlExpression *
 
 
 
-void KeyedJoinInfo::optimizeTransfer(OwnedHqlExpr & targetDataset, OwnedHqlExpr & targetTransform, OwnedHqlExpr & filter, OwnedHqlExpr * extraFilter)
+void KeyedJoinInfo::optimizeTransfer(SharedHqlExpr & targetDataset, SharedHqlExpr & targetTransform, SharedHqlExpr & filter, OwnedHqlExpr * extraFilter)
 {
     IHqlExpression * dataset = expr->queryChild(0);
     if (canOptimizeTransfer)
@@ -1095,7 +1095,7 @@ bool KeyedJoinInfo::processFilter()
     return monitors->isKeyed();
 }
 
-void KeyedJoinInfo::splitFilter(IHqlExpression * filter, OwnedHqlExpr & keyTarget)
+void KeyedJoinInfo::splitFilter(IHqlExpression * filter, SharedHqlExpr & keyTarget)
 {
     if (!filter) return;
     if (filter->getOperator() == no_and)

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -6687,7 +6687,7 @@ void HqlCppTranslator::doBuildAssignChoose(BuildCtx & ctx, const CHqlBoundTarget
 //-- compare (no_eq,no_ne,no_lt,no_gt,no_le,no_ge) --
 
 //Are the arguments scalar?  If so return the scalar arguments.
-static bool getIsScalarCompare(IHqlExpression * expr, OwnedHqlExpr & left, OwnedHqlExpr & right)
+static bool getIsScalarCompare(IHqlExpression * expr, SharedHqlExpr & left, SharedHqlExpr & right)
 {
     left.set(expr->queryChild(0));
     right.set(expr->queryChild(1));
@@ -7747,7 +7747,7 @@ void HqlCppTranslator::expandSimpleOrder(IHqlExpression * left, IHqlExpression *
 }
 
 
-void HqlCppTranslator::expandOrder(IHqlExpression * expr, HqlExprArray & leftValues, HqlExprArray & rightValues, OwnedHqlExpr & defaultValue)
+void HqlCppTranslator::expandOrder(IHqlExpression * expr, HqlExprArray & leftValues, HqlExprArray & rightValues, SharedHqlExpr & defaultValue)
 {
     OwnedHqlExpr left = normalizeListCasts(expr->queryChild(0));
     OwnedHqlExpr right = normalizeListCasts(expr->queryChild(1));

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -171,7 +171,7 @@ interface IHqlCppDatasetCursor : public IInterface
     virtual void buildCount(BuildCtx & ctx, CHqlBoundExpr & tgt) = 0;
     virtual void buildExists(BuildCtx & ctx, CHqlBoundExpr & tgt) = 0;
     virtual BoundRow * buildIterateLoop(BuildCtx & ctx, bool needToBreak) = 0;
-    virtual void buildIterateClass(BuildCtx & ctx, OwnedHqlExpr & iter, OwnedHqlExpr & row) = 0;
+    virtual void buildIterateClass(BuildCtx & ctx, SharedHqlExpr & iter, SharedHqlExpr & row) = 0;
     virtual BoundRow * buildSelect(BuildCtx & ctx, IHqlExpression * indexExpr) = 0;
     virtual void buildIterateMembers(BuildCtx & declarectx, BuildCtx & initctx) = 0;
 };
@@ -1485,7 +1485,7 @@ public:
     void doBuildAggregateProcessTransform(BuildCtx & ctx, BoundRow * selfRow, IHqlExpression * expr, IHqlExpression * alreadyDoneExpr);
 
 
-    void processUserAggregateTransform(IHqlExpression * expr, IHqlExpression * transform, OwnedHqlExpr & firstTransform, OwnedHqlExpr & nextTransform);
+    void processUserAggregateTransform(IHqlExpression * expr, IHqlExpression * transform, SharedHqlExpr & firstTransform, SharedHqlExpr & nextTransform);
     void doBuildUserAggregateFuncs(BuildCtx & ctx, IHqlExpression * expr, bool & requiresOrderedMerge);
     void doBuildUserAggregateProcessTransform(BuildCtx & ctx, BoundRow * selfRow, IHqlExpression * expr, IHqlExpression * transform, IHqlExpression * alreadyDoneExpr);
     void doBuildUserMergeAggregateFunc(BuildCtx & ctx, IHqlExpression * expr, IHqlExpression * mergeTransform);
@@ -1573,7 +1573,7 @@ public:
     IHqlExpression * doCompare(BuildCtx & ctx, IHqlExpression *sortList, const DatasetReference & dataset);
     void doCompareLeftRight(BuildCtx & ctx, const char * funcname, const DatasetReference & datasetLeft, const DatasetReference & datasetRight, HqlExprArray & left, HqlExprArray & right);
     void buildSlidingMatchFunction(BuildCtx & ctx, HqlExprArray & leftEq, HqlExprArray & rightEq, HqlExprArray & slidingMatches, const char * funcname, unsigned childIndex, const DatasetReference & datasetL, const DatasetReference & datasetR);
-    void doBuildIndexOutputTransform(BuildCtx & ctx, IHqlExpression * record, OwnedHqlExpr & rawRecord);
+    void doBuildIndexOutputTransform(BuildCtx & ctx, IHqlExpression * record, SharedHqlExpr & rawRecord);
 
     void buildKeyedJoinExtra(ActivityInstance & instance, IHqlExpression * expr, KeyedJoinInfo * joinKey);
     void buildKeyJoinIndexReadHelper(ActivityInstance & instance, IHqlExpression * expr, KeyedJoinInfo * joinKey);
@@ -1621,7 +1621,7 @@ public:
     bool insideRemoteGraph(BuildCtx & ctx);
     bool isCurrentActiveGraph(BuildCtx & ctx, IHqlExpression * graphTag);
 
-    void buildXmlReadChildrenIterator(BuildCtx & subctx, const char * iterTag, IHqlExpression * rowName, OwnedHqlExpr & subRowExpr);
+    void buildXmlReadChildrenIterator(BuildCtx & subctx, const char * iterTag, IHqlExpression * rowName, SharedHqlExpr & subRowExpr);
     void buildXmlReadTransform(IHqlExpression * dataset, StringBuffer & className, bool & usesContents);
     void doBuildXmlReadMember(ActivityInstance & instance, IHqlExpression * expr, const char * functionName, bool & usesContents);
 
@@ -1689,7 +1689,7 @@ protected:
     void doBuildAssignCompare(BuildCtx & ctx, EvaluateCompareInfo & target, HqlExprArray & leftValues, HqlExprArray & rightValues, bool isFirst, bool isOuter);
     void expandRowOrder(IHqlExpression * selector, IHqlExpression * record, HqlExprArray & values, bool isRow);
     void expandSimpleOrder(IHqlExpression * left, IHqlExpression * right, HqlExprArray & leftValues, HqlExprArray & rightValues);
-    void expandOrder(IHqlExpression * expr, HqlExprArray & leftValues, HqlExprArray & rightValues, OwnedHqlExpr & defaultValue);
+    void expandOrder(IHqlExpression * expr, HqlExprArray & leftValues, HqlExprArray & rightValues, SharedHqlExpr & defaultValue);
     void optimizeOrderValues(HqlExprArray & leftValues, HqlExprArray & rightValues, bool isEqualityCompare);
     IHqlExpression * querySimpleOrderSelector(IHqlExpression * expr);
 
@@ -1702,7 +1702,7 @@ protected:
     IHqlExpression * normalizeGlobalIfCondition(BuildCtx & ctx, IHqlExpression * expr);
     void substituteClusterSize(HqlExprArray & exprs);
     void throwCannotCast(ITypeInfo * from, ITypeInfo * to);
-    void splitFuzzyCondition(IHqlExpression * condition, IHqlExpression * atmostCond, OwnedHqlExpr & fuzzy, OwnedHqlExpr & hard);
+    void splitFuzzyCondition(IHqlExpression * condition, IHqlExpression * atmostCond, SharedHqlExpr & fuzzy, SharedHqlExpr & hard);
 
     void ensureSerialized(BuildCtx & ctx, const CHqlBoundTarget & variable);
 

--- a/ecl/hqlcpp/hqlcse.cpp
+++ b/ecl/hqlcpp/hqlcse.cpp
@@ -1133,7 +1133,7 @@ IHqlExpression * spotScalarCSE(IHqlExpression * expr, IHqlExpression * limit)
 }
 
 
-void spotScalarCSE(OwnedHqlExpr & expr, OwnedHqlExpr & associated, IHqlExpression * limit, IHqlExpression * invariantSelector)
+void spotScalarCSE(SharedHqlExpr & expr, SharedHqlExpr & associated, IHqlExpression * limit, IHqlExpression * invariantSelector)
 {
     CseSpotter spotter;
     spotter.analyse(expr, 0);

--- a/ecl/hqlcpp/hqlcse.ipp
+++ b/ecl/hqlcpp/hqlcse.ipp
@@ -214,7 +214,7 @@ protected:
 
 
 IHqlExpression * spotScalarCSE(IHqlExpression * expr, IHqlExpression * limit = NULL);
-void spotScalarCSE(OwnedHqlExpr & expr, OwnedHqlExpr & associated, IHqlExpression * limit, IHqlExpression * invariantSelector);
+void spotScalarCSE(SharedHqlExpr & expr, SharedHqlExpr & associated, IHqlExpression * limit, IHqlExpression * invariantSelector);
 void spotScalarCSE(HqlExprArray & exprs, HqlExprArray & associated, IHqlExpression * limit, IHqlExpression * invariantSelector);
 
 //---------------------------------------------------------------------------

--- a/ecl/hqlcpp/hqlcset.cpp
+++ b/ecl/hqlcpp/hqlcset.cpp
@@ -91,7 +91,7 @@ BoundRow * BaseDatasetCursor::buildIterateLoop(BuildCtx & ctx, bool needToBreak)
     return cursor;
 }
 
-void BaseDatasetCursor::buildIterateClass(BuildCtx & ctx, OwnedHqlExpr & iter, OwnedHqlExpr & row)
+void BaseDatasetCursor::buildIterateClass(BuildCtx & ctx, SharedHqlExpr & iter, SharedHqlExpr & row)
 {
     StringBuffer cursorName, rowName;
     buildIterateClass(ctx, cursorName, NULL);

--- a/ecl/hqlcpp/hqlcset.ipp
+++ b/ecl/hqlcpp/hqlcset.ipp
@@ -25,7 +25,7 @@ public:
     IMPLEMENT_IINTERFACE
 
     virtual BoundRow * buildIterateLoop(BuildCtx & ctx, bool needToBreak);
-    virtual void buildIterateClass(BuildCtx & ctx, OwnedHqlExpr & iter, OwnedHqlExpr & row);
+    virtual void buildIterateClass(BuildCtx & ctx, SharedHqlExpr & iter, SharedHqlExpr & row);
     virtual BoundRow * buildSelect(BuildCtx & ctx, IHqlExpression * indexExpr);
     virtual void buildIterateMembers(BuildCtx & declarectx, BuildCtx & initctx);
 

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -231,7 +231,7 @@ static IHqlExpression * createResultName(IHqlExpression * name)
 
 //---------------------------------------------------------------------------
 
-void extractAtmostArgs(IHqlExpression * atmost, OwnedHqlExpr & atmostCond, OwnedHqlExpr & atmostLimit)
+void extractAtmostArgs(IHqlExpression * atmost, SharedHqlExpr & atmostCond, SharedHqlExpr & atmostLimit)
 {
     atmostLimit.set(queryZero());
     if (atmost)
@@ -270,7 +270,7 @@ static bool matchesAtmostCondition(IHqlExpression * cond, HqlExprArray & atConds
     return true;
 }
 
-void HqlCppTranslator::splitFuzzyCondition(IHqlExpression * condition, IHqlExpression * atmostCond, OwnedHqlExpr & fuzzy, OwnedHqlExpr & hard)
+void HqlCppTranslator::splitFuzzyCondition(IHqlExpression * condition, IHqlExpression * atmostCond, SharedHqlExpr & fuzzy, SharedHqlExpr & hard)
 {
     if (atmostCond)
     {
@@ -9636,7 +9636,7 @@ static void createOutputIndexTransform(HqlExprArray & assigns, IHqlExpression * 
 }
 
 
-void HqlCppTranslator::doBuildIndexOutputTransform(BuildCtx & ctx, IHqlExpression * record, OwnedHqlExpr & rawRecord)
+void HqlCppTranslator::doBuildIndexOutputTransform(BuildCtx & ctx, IHqlExpression * record, SharedHqlExpr & rawRecord)
 {
     OwnedHqlExpr srcDataset = createDataset(no_anon, LINK(record));
 
@@ -12657,7 +12657,7 @@ IHqlExpression * NextTransformCreator::transform(IHqlExpression * expr)
 
 //------------------------------------------------------------------------------------------------
 
-void HqlCppTranslator::processUserAggregateTransform(IHqlExpression * expr, IHqlExpression * transform, OwnedHqlExpr & firstTransform, OwnedHqlExpr & nextTransform)
+void HqlCppTranslator::processUserAggregateTransform(IHqlExpression * expr, IHqlExpression * transform, SharedHqlExpr & firstTransform, SharedHqlExpr & nextTransform)
 {
     if (isKnownTransform(transform))
     {

--- a/ecl/hqlcpp/hqlhtcpp.ipp
+++ b/ecl/hqlcpp/hqlhtcpp.ipp
@@ -290,7 +290,7 @@ protected:
     bool            matchedDataset;
 };
 
-void extractAtmostArgs(IHqlExpression * atmost, OwnedHqlExpr & atmostCond, OwnedHqlExpr & atmostLimit);
+void extractAtmostArgs(IHqlExpression * atmost, SharedHqlExpr & atmostCond, SharedHqlExpr & atmostLimit);
 
 IHqlExpression * extractFilterConditions(HqlExprAttr & invariant, IHqlExpression * expr, IHqlExpression * dataset, bool spotCSE);
 bool isLibraryScope(IHqlExpression * expr);

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -696,13 +696,13 @@ public:
 
     virtual void buildMembers(IHqlExpression * expr) = 0;
     virtual void buildTransformFpos(BuildCtx & transformCtx) = 0;
-    virtual void extractMonitors(IHqlExpression * ds, OwnedHqlExpr & unkeyedFilter, HqlExprArray & conds);
+    virtual void extractMonitors(IHqlExpression * ds, SharedHqlExpr & unkeyedFilter, HqlExprArray & conds);
     virtual void buildTransformElements(BuildCtx & ctx, IHqlExpression * expr, bool ignoreFilters);
     virtual void buildTransform(IHqlExpression * expr) = 0;
     virtual void analyse(IHqlExpression * expr);
 
     void buildFilenameMember();
-    void appendFilter(OwnedHqlExpr & unkeyedFilter, IHqlExpression * expr);
+    void appendFilter(SharedHqlExpr & unkeyedFilter, IHqlExpression * expr);
     void buildKeyedLimitHelper(IHqlExpression * expr);
     void buildLimits(BuildCtx & classctx, IHqlExpression * expr, unique_id_t id);
     void buildReadMembers( IHqlExpression * expr);
@@ -735,7 +735,7 @@ protected:
     void buildGroupingMonitors(IHqlExpression * expr, MonitorExtractor & monitors);
     void buildGroupAggregateTransformBody(BuildCtx & transformctx, IHqlExpression * expr, bool useExtract);
     void buildNormalizeHelpers(IHqlExpression * expr);
-    void buildTargetCursor(Owned<BoundRow> & tempRow, Owned<BoundRow> & rowBuilder, BuildCtx & ctx, IHqlExpression * expr);
+    void buildTargetCursor(Shared<BoundRow> & tempRow, Shared<BoundRow> & rowBuilder, BuildCtx & ctx, IHqlExpression * expr);
     void associateTargetCursor(BuildCtx & subctx, BuildCtx & ctx, BoundRow * tempRow, BoundRow * rowBuilder, IHqlExpression * expr);
     IHqlExpression * ensureAggregateGroupingAliased(IHqlExpression * aggregate);
     void gatherSteppingMeta(IHqlExpression * expr, SourceSteppingInfo & info);
@@ -1042,7 +1042,7 @@ void SourceBuilder::analyse(IHqlExpression * expr)
     }
 }
 
-void SourceBuilder::appendFilter(OwnedHqlExpr & unkeyedFilter, IHqlExpression * expr)
+void SourceBuilder::appendFilter(SharedHqlExpr & unkeyedFilter, IHqlExpression * expr)
 {
     if (expr)
     {
@@ -1189,7 +1189,7 @@ void SourceBuilder::buildTransformBody(BuildCtx & transformCtx, IHqlExpression *
     rootSelfRow = NULL;
 }
 
-void SourceBuilder::buildTargetCursor(Owned<BoundRow> & tempRow, Owned<BoundRow> & rowBuilder, BuildCtx & ctx, IHqlExpression * expr)
+void SourceBuilder::buildTargetCursor(Shared<BoundRow> & tempRow, Shared<BoundRow> & rowBuilder, BuildCtx & ctx, IHqlExpression * expr)
 {
     assertex(lastTransformer != NULL);
     if (expr == lastTransformer)
@@ -1661,7 +1661,7 @@ void SourceBuilder::checkDependencies(BuildCtx & ctx, IHqlExpression * expr)
     translator.addFileDependency(nameExpr, bound);
 }
 
-void SourceBuilder::extractMonitors(IHqlExpression * ds, OwnedHqlExpr & unkeyedFilter, HqlExprArray & conds)
+void SourceBuilder::extractMonitors(IHqlExpression * ds, SharedHqlExpr & unkeyedFilter, HqlExprArray & conds)
 {
     ForEachItemIn(i, conds)
     {
@@ -2511,7 +2511,7 @@ public:
 
     virtual void buildMembers(IHqlExpression * expr);
     virtual void buildTransformFpos(BuildCtx & transformCtx);
-    virtual void extractMonitors(IHqlExpression * ds, OwnedHqlExpr & unkeyedFilter, HqlExprArray & conds);
+    virtual void extractMonitors(IHqlExpression * ds, SharedHqlExpr & unkeyedFilter, HqlExprArray & conds);
 
 protected:
     virtual void buildFlagsMember(IHqlExpression * expr);
@@ -2635,7 +2635,7 @@ void DiskReadBuilderBase::buildTransformFpos(BuildCtx & transformCtx)
 }
 
 
-void DiskReadBuilderBase::extractMonitors(IHqlExpression * ds, OwnedHqlExpr & unkeyedFilter, HqlExprArray & conds)
+void DiskReadBuilderBase::extractMonitors(IHqlExpression * ds, SharedHqlExpr & unkeyedFilter, HqlExprArray & conds)
 {
     ForEachItemIn(i, conds)
     {
@@ -3959,13 +3959,13 @@ static IHqlExpression * createCompareRecast(node_operator op, IHqlExpression * v
 }
 
 
-void MonitorExtractor::extractCompareInformation(BuildCtx & ctx, IHqlExpression * expr, OwnedHqlExpr & compare, OwnedHqlExpr & normalized, IHqlExpression * expandedSelector, bool isComputed)
+void MonitorExtractor::extractCompareInformation(BuildCtx & ctx, IHqlExpression * expr, SharedHqlExpr & compare, SharedHqlExpr & normalized, IHqlExpression * expandedSelector, bool isComputed)
 {
     extractCompareInformation(ctx, expr->queryChild(0), expr->queryChild(1), compare, normalized, expandedSelector, isComputed);
 }
 
 
-void MonitorExtractor::extractCompareInformation(BuildCtx & ctx, IHqlExpression * lhs, IHqlExpression * value, OwnedHqlExpr & compare, OwnedHqlExpr & normalized, IHqlExpression * expandedSelector, bool isComputed)
+void MonitorExtractor::extractCompareInformation(BuildCtx & ctx, IHqlExpression * lhs, IHqlExpression * value, SharedHqlExpr & compare, SharedHqlExpr & normalized, IHqlExpression * expandedSelector, bool isComputed)
 {
     LinkedHqlExpr compareValue = value->queryBody();
     OwnedHqlExpr recastValue;
@@ -5229,7 +5229,7 @@ static IHqlExpression * queryLengthFromRange(IHqlExpression * range)
     }
 }
 
-static void extendRangeCheck(OwnedHqlExpr & globalGuard, OwnedHqlExpr & localCond, IHqlExpression * selector, IHqlExpression * lengthExpr, bool compareEqual)
+static void extendRangeCheck(SharedHqlExpr & globalGuard, SharedHqlExpr & localCond, IHqlExpression * selector, IHqlExpression * lengthExpr, bool compareEqual)
 {
 #if 0
     //This might be a good idea, but probably doesn't make a great deal of difference at runtime
@@ -5645,14 +5645,14 @@ bool MonitorExtractor::containsTableSelects(IHqlExpression * expr)
 }
 
 
-void MonitorExtractor::extractFilters(IHqlExpression * expr, OwnedHqlExpr & extraFilter)
+void MonitorExtractor::extractFilters(IHqlExpression * expr, SharedHqlExpr & extraFilter)
 {
     HqlExprArray conds;
     expr->unwindList(conds, no_and);
     extractFilters(conds, extraFilter);
 }
 
-void MonitorExtractor::extractFilters(HqlExprArray & exprs, OwnedHqlExpr & extraFilter)
+void MonitorExtractor::extractFilters(HqlExprArray & exprs, SharedHqlExpr & extraFilter)
 {
     OwnedHqlExpr savedFilter = keyed.postFilter.getClear();
     ForEachItemIn(i1, exprs)
@@ -6088,7 +6088,7 @@ public:
     }
 
     virtual void buildMembers(IHqlExpression * expr);
-    virtual void extractMonitors(IHqlExpression * ds, OwnedHqlExpr & unkeyedFilter, HqlExprArray & conds);
+    virtual void extractMonitors(IHqlExpression * ds, SharedHqlExpr & unkeyedFilter, HqlExprArray & conds);
 
 protected:
     virtual void buildFlagsMember(IHqlExpression * expr);
@@ -6187,7 +6187,7 @@ void IndexReadBuilderBase::buildFlagsMember(IHqlExpression * expr)
         translator.doBuildUnsignedFunction(instance->classctx, "getFlags", flags.str()+1);
 }
 
-void IndexReadBuilderBase::extractMonitors(IHqlExpression * ds, OwnedHqlExpr & unkeyedFilter, HqlExprArray & conds)
+void IndexReadBuilderBase::extractMonitors(IHqlExpression * ds, SharedHqlExpr & unkeyedFilter, HqlExprArray & conds)
 {
     OwnedHqlExpr extraFilter;
     monitors.extractFilters(conds, extraFilter);

--- a/ecl/hqlcpp/hqlsource.ipp
+++ b/ecl/hqlcpp/hqlsource.ipp
@@ -144,8 +144,8 @@ public:
 
     void appendFilter(IHqlExpression * expr)                { keyed.appendPostFilter(expr); }
     void buildSegments(BuildCtx & ctx, const char * listName, bool _ignoreUnkeyed);
-    void extractFilters(IHqlExpression * filter, OwnedHqlExpr & extraFilter);
-    void extractFilters(HqlExprArray & exprs, OwnedHqlExpr & extraFilter);
+    void extractFilters(IHqlExpression * filter, SharedHqlExpr & extraFilter);
+    void extractFilters(HqlExprArray & exprs, SharedHqlExpr & extraFilter);
     void extractFiltersFromFilterDs(IHqlExpression * expr);
     void extractAllFilters(IHqlExpression * filter);
     IHqlExpression * queryExtraFilter()                     { return keyed.postFilter; }
@@ -202,8 +202,8 @@ protected:
     bool okToKey(IHqlExpression * select, KeyedKind keyedKind);
     IHqlExpression * queryKeyableSelector(IHqlExpression * expr);
     IHqlExpression * querySimpleJoinValue(IHqlExpression * field);
-    void extractCompareInformation(BuildCtx & ctx, IHqlExpression * expr, OwnedHqlExpr & compare, OwnedHqlExpr & normalized, IHqlExpression * expandedSelector, bool isTranslated);
-    void extractCompareInformation(BuildCtx & ctx, IHqlExpression * lhs, IHqlExpression * value, OwnedHqlExpr & compare, OwnedHqlExpr & normalized, IHqlExpression * expandedSelector, bool isTranslated);
+    void extractCompareInformation(BuildCtx & ctx, IHqlExpression * expr, SharedHqlExpr & compare, SharedHqlExpr & normalized, IHqlExpression * expandedSelector, bool isTranslated);
+    void extractCompareInformation(BuildCtx & ctx, IHqlExpression * lhs, IHqlExpression * value, SharedHqlExpr & compare, SharedHqlExpr & normalized, IHqlExpression * expandedSelector, bool isTranslated);
     IHqlExpression * unwindConjunction(HqlExprArray & matches, IHqlExpression * expr);
 
 protected:

--- a/ecl/hqlcpp/hqlstep.cpp
+++ b/ecl/hqlcpp/hqlstep.cpp
@@ -79,7 +79,7 @@ protected:
     bool extractCondition(HqlExprArray & args, IHqlExpression * searchField);
     bool extractComparison(IHqlExpression * lhs, IHqlExpression * rhs, IHqlExpression * searchField, bool isEqual = false);
     bool isLeftRightInvariant(IHqlExpression * expr);
-    IHqlExpression * simplifyArgument(IHqlExpression * expr, OwnedHqlExpr & delta, bool invert);
+    IHqlExpression * simplifyArgument(IHqlExpression * expr, SharedHqlExpr & delta, bool invert);
 
 protected:
     HqlExprArray equalities;
@@ -193,7 +193,7 @@ bool SteppingCondition::isLeftRightInvariant(IHqlExpression * expr)
 }
 
 
-void adjustValue(OwnedHqlExpr & total, IHqlExpression * value, bool invert)
+void adjustValue(SharedHqlExpr & total, IHqlExpression * value, bool invert)
 {
     if (total)
         total.setown(adjustBoundIntegerValues(total, value, invert));
@@ -204,7 +204,7 @@ void adjustValue(OwnedHqlExpr & total, IHqlExpression * value, bool invert)
 }
 
 
-IHqlExpression * SteppingCondition::simplifyArgument(IHqlExpression * expr, OwnedHqlExpr & delta, bool invert)
+IHqlExpression * SteppingCondition::simplifyArgument(IHqlExpression * expr, SharedHqlExpr & delta, bool invert)
 {
     loop
     {

--- a/ecl/hqlcpp/hqltcppc.cpp
+++ b/ecl/hqlcpp/hqltcppc.cpp
@@ -2629,7 +2629,7 @@ void CXmlColumnInfo::buildColumnExpr(HqlCppTranslator & translator, BuildCtx & c
     translator.buildExpr(ctx, call, bound);
 }
 
-void HqlCppTranslator::buildXmlReadChildrenIterator(BuildCtx & ctx, const char * iterTag, IHqlExpression * rowName, OwnedHqlExpr & subRowExpr)
+void HqlCppTranslator::buildXmlReadChildrenIterator(BuildCtx & ctx, const char * iterTag, IHqlExpression * rowName, SharedHqlExpr & subRowExpr)
 {
     StringBuffer s, iterName, subRowName;
     unique_id_t id = getUniqueId();
@@ -3404,7 +3404,7 @@ IHqlExpression * SerializationRow::ensureSerialized(BuildCtx & ctx, IHqlExpressi
 
 IHqlExpression * SerializationRow::ensureSerialized(IHqlExpression * path, IHqlExpression * colocal, bool isConditional)
 {
-    OwnedHqlExpr * mapped = mapping.getValue(path);
+    SharedHqlExpr * mapped = mapping.getValue(path);
     if (mapped)
         return LINK(mapped->get());
 

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -132,18 +132,18 @@ public:
     void extractGlobal(IHqlExpression * expr, bool isRoxie);
     void extractStoredInfo(IHqlExpression * expr, IHqlExpression * originalValue, bool isRoxie);
     void checkFew(HqlCppTranslator & translator, IHqlExpression * value);
-    void splitGlobalDefinition(ITypeInfo * type, IHqlExpression * value, IConstWorkUnit * wu, OwnedHqlExpr & setOutput, OwnedHqlExpr * getOutput, bool isRoxie);
+    void splitGlobalDefinition(ITypeInfo * type, IHqlExpression * value, IConstWorkUnit * wu, SharedHqlExpr & setOutput, OwnedHqlExpr * getOutput, bool isRoxie);
     IHqlExpression * getStoredKey();
     void preventDiskSpill() { few = true; }
     IHqlExpression * queryCluster() const { return cluster; }
 
 protected:
-    void doSplitGlobalDefinition(ITypeInfo * type, IHqlExpression * value, IConstWorkUnit * wu, OwnedHqlExpr & setOutput, OwnedHqlExpr * getOutput, bool isRoxie);
+    void doSplitGlobalDefinition(ITypeInfo * type, IHqlExpression * value, IConstWorkUnit * wu, SharedHqlExpr & setOutput, OwnedHqlExpr * getOutput, bool isRoxie);
     IHqlExpression * createSetValue(IHqlExpression * value, IHqlExpression * aliasName);
-    void createSmallOutput(IHqlExpression * value, OwnedHqlExpr & setOutput);
+    void createSmallOutput(IHqlExpression * value, SharedHqlExpr & setOutput);
     IHqlExpression * queryAlias(IHqlExpression * value);
     IHqlExpression * queryFilename(IHqlExpression * value, IConstWorkUnit * wu, bool isRoxie);
-    void splitSmallDataset(IHqlExpression * value, OwnedHqlExpr & setOutput, OwnedHqlExpr * getOutput);
+    void splitSmallDataset(IHqlExpression * value, SharedHqlExpr & setOutput, OwnedHqlExpr * getOutput);
     void setCluster(IHqlExpression * expr);
 
 public:
@@ -1040,7 +1040,7 @@ void ThorScalarTransformer::doAnalyseExpr(IHqlExpression * expr)
 }
 
 
-void ThorScalarTransformer::createHoisted(IHqlExpression * expr, OwnedHqlExpr & setResultStmt, OwnedHqlExpr & getResult, bool addWrapper)
+void ThorScalarTransformer::createHoisted(IHqlExpression * expr, SharedHqlExpr & setResultStmt, SharedHqlExpr & getResult, bool addWrapper)
 {
     IHqlExpression * value = expr;
     HqlExprArray actions;
@@ -1216,7 +1216,7 @@ void SequenceNumberAllocator::nextSequence(HqlExprArray & args, IHqlExpression *
         *duplicate = false;
     if (name)
     {
-        OwnedHqlExpr * matched = namedMap.getValue(name);
+        SharedHqlExpr * matched = namedMap.getValue(name);
         if (matched)
         {
             StringBuffer nameText;
@@ -4639,12 +4639,12 @@ void GlobalAttributeInfo::extractStoredInfo(IHqlExpression * expr, IHqlExpressio
 }
 
 
-void GlobalAttributeInfo::splitGlobalDefinition(ITypeInfo * type, IHqlExpression * value, IConstWorkUnit * wu, OwnedHqlExpr & setOutput, OwnedHqlExpr * getOutput, bool isRoxie)
+void GlobalAttributeInfo::splitGlobalDefinition(ITypeInfo * type, IHqlExpression * value, IConstWorkUnit * wu, SharedHqlExpr & setOutput, OwnedHqlExpr * getOutput, bool isRoxie)
 {
     doSplitGlobalDefinition(type, value, wu, setOutput, getOutput, isRoxie);
 }
 
-void GlobalAttributeInfo::doSplitGlobalDefinition(ITypeInfo * type, IHqlExpression * value, IConstWorkUnit * wu, OwnedHqlExpr & setOutput, OwnedHqlExpr * getOutput, bool isRoxie)
+void GlobalAttributeInfo::doSplitGlobalDefinition(ITypeInfo * type, IHqlExpression * value, IConstWorkUnit * wu, SharedHqlExpr & setOutput, OwnedHqlExpr * getOutput, bool isRoxie)
 {
     OwnedHqlExpr targetName;
     if (storedName)
@@ -4791,7 +4791,7 @@ void GlobalAttributeInfo::doSplitGlobalDefinition(ITypeInfo * type, IHqlExpressi
     }
 }
 
-void GlobalAttributeInfo::createSmallOutput(IHqlExpression * value, OwnedHqlExpr & setOutput)
+void GlobalAttributeInfo::createSmallOutput(IHqlExpression * value, SharedHqlExpr & setOutput)
 {
     if (value->getOperator() == no_temptable)
     {
@@ -4837,7 +4837,7 @@ void GlobalAttributeInfo::checkFew(HqlCppTranslator & translator, IHqlExpression
 }
 
 
-void GlobalAttributeInfo::splitSmallDataset(IHqlExpression * value, OwnedHqlExpr & setOutput, OwnedHqlExpr * getOutput)
+void GlobalAttributeInfo::splitSmallDataset(IHqlExpression * value, SharedHqlExpr & setOutput, OwnedHqlExpr * getOutput)
 {
     createSmallOutput(value, setOutput);
 
@@ -8066,7 +8066,7 @@ void NestedSelectorNormalizer::analyseExpr(IHqlExpression * expr)
     }
 }
 
-static IHqlExpression * splitSelector(IHqlExpression * expr, OwnedHqlExpr & oldDataset)
+static IHqlExpression * splitSelector(IHqlExpression * expr, SharedHqlExpr & oldDataset)
 {
     assertex(expr->getOperator() == no_select);
     IHqlExpression * ds = expr->queryChild(0);
@@ -9473,7 +9473,7 @@ public:
             {
                 OwnedHqlExpr attr = createLocationAttr(location->querySourcePath(), location->getStartLine(), location->getStartColumn(), 0);
                 Linked<LocationInfo> info;
-                Owned<LocationInfo> * match = map.getValue(attr);
+                Shared<LocationInfo> * match = map.getValue(attr);
                 if (match)
                     info.set(*match);
                 else

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -112,7 +112,7 @@ public:
     inline bool needToTransform()                                   { return seenCandidate || containsUnknownIndependentContents; }
 
 protected:
-    void createHoisted(IHqlExpression * expr, OwnedHqlExpr & setResultStmt, OwnedHqlExpr & getResult, bool addWrapper);
+    void createHoisted(IHqlExpression * expr, SharedHqlExpr & setResultStmt, SharedHqlExpr & getResult, bool addWrapper);
     virtual ANewTransformInfo * createTransformInfo(IHqlExpression * expr) { return CREATE_NEWTRANSFORMINFO(ThorScalarInfo, expr); }
     virtual IHqlExpression * queryAlreadyTransformed(IHqlExpression * expr);
     virtual IHqlExpression * queryAlreadyTransformedSelector(IHqlExpression * expr);

--- a/ecl/hthor/hthorkey.cpp
+++ b/ecl/hthor/hthorkey.cpp
@@ -73,7 +73,7 @@ static IKeyIndex *openKeyFile(IDistributedFilePart & keyFile)
     throw MakeStringException(1001, "Could not open key file at %s%s", url.str(), (numCopies > 1) ? " or any alternate location." : ".");
 }
 
-void enterSingletonSuperfiles(Owned<IDistributedFile> & file)
+void enterSingletonSuperfiles(Shared<IDistributedFile> & file)
 {
     IDistributedSuperFile * super = file->querySuperFile();
     while(super && (super->numSubFiles() == 1))

--- a/esp/esplib/pqueue.hpp
+++ b/esp/esplib/pqueue.hpp
@@ -261,7 +261,7 @@ private:
     }
 
  
-    WaitQueue<StlLinked<ITask> > queue;
+    WaitQueue<Linked<ITask> > queue;
 
     size32_t maxsize;
     friend WorkerThread;

--- a/esp/esplib/respool.hpp
+++ b/esp/esplib/respool.hpp
@@ -53,7 +53,7 @@ public:
         factory.set(fac);
     }
 
-    StlLinked<T> get(long timeout=0)
+    Linked<T> get(long timeout=0)
     {   
         const long interval=1000;
 
@@ -61,15 +61,15 @@ public:
         {
             {
                 CriticalBlock b(crit); 
-                typename std::vector<StlLinked<T> >::iterator it;
+                typename std::vector<Linked<T> >::iterator it;
                 for(it=resources.begin();it!=resources.end();it++)
                 {
                     if(it->get() == NULL)
                     {
-                        StlLinked<T> e = factory->createResource();
+                        Owned<T> e = factory->createResource();
                         if(e)
                         {
-                            it->setown(e.get());
+                            it->set(e.get());
                             return e;
                         }
                     }
@@ -106,7 +106,7 @@ public:
 
         {
         CriticalBlock b(crit); 
-        typename std::vector<StlLinked<T> >::iterator it;
+        typename std::vector<Linked<T> >::iterator it;
         for(it=resources.begin();it!=resources.end();it++)
         {
             if(it->get() && it->get() == t)
@@ -121,7 +121,7 @@ public:
     void clearAll()
     {
         CriticalBlock b(crit); 
-        typename std::vector<StlLinked<T> >::iterator it;
+        typename std::vector<Linked<T> >::iterator it;
         for(it=resources.begin();it!=resources.end();it++)
         {
             if(it->get())
@@ -134,7 +134,7 @@ public:
 protected:
     CriticalSection crit;
     Semaphore sem;
-    std::vector<StlLinked<T> > resources;
+    std::vector<Linked<T> > resources;
     Linked<IResourceFactory<T> > factory;
 };
 

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -1608,8 +1608,8 @@ void Cws_machineEx::enumerateRunningProcesses(CMachineInfoThreadParam* pParam,
                                                              IArrayOf<IEspProcessInfo>& runningProcesses,
                                                              bool bLinuxInstance,
                                                              bool bFilterProcesses,
-                                                             map<string, StlLinked<IEspSWRunInfo> >* processMap,
-                                                             map<int, StlLinked<IEspSWRunInfo> >& pidMap,
+                                                             map<string, Linked<IEspSWRunInfo> >* processMap,
+                                                             map<int, Linked<IEspSWRunInfo> >& pidMap,
                                                              set<string>* pRequiredProcesses)
 {
     const bool bThorMasterOrSlave = !strncmp(pParam->m_sProcessType, "Thor", 4);
@@ -1686,11 +1686,11 @@ void Cws_machineEx::enumerateRunningProcesses(CMachineInfoThreadParam* pParam,
         if ((bLinuxInstance && (!bFilterProcesses || *pszName != '[')) ||
              (!bLinuxInstance && *pszName != '['))
       {
-         map<string, StlLinked<IEspSWRunInfo> >::iterator it;
+         map<string, Linked<IEspSWRunInfo> >::iterator it;
             if (processMap)
                 it = processMap->find(pszName);
 
-            StlLinked<IEspSWRunInfo> lptr;
+            Linked<IEspSWRunInfo> lptr;
          if ( !processMap || it == processMap->end()) //not in the set
          {
               Owned<IEspSWRunInfo> info = static_cast<IEspSWRunInfo*>(new CSWRunInfo(""));
@@ -1699,16 +1699,16 @@ void Cws_machineEx::enumerateRunningProcesses(CMachineInfoThreadParam* pParam,
                 lptr = info.get();
 
                 if (processMap)
-                    processMap->insert(pair<string, StlLinked<IEspSWRunInfo> >(pszName, lptr));
+                    processMap->insert(pair<string, Linked<IEspSWRunInfo> >(pszName, lptr));
          }
          else
          {
-                const StlLinked<IEspSWRunInfo>& linkedPtr = (*it).second;
+                const Linked<IEspSWRunInfo>& linkedPtr = (*it).second;
               lptr = linkedPtr;
             lptr->setInstances( lptr->getInstances() + 1);
          }
 
-            pidMap.insert(pair<int, StlLinked<IEspSWRunInfo> >(pid, lptr));
+            pidMap.insert(pair<int, Linked<IEspSWRunInfo> >(pid, lptr));
       }
     }
 }
@@ -1788,8 +1788,8 @@ void Cws_machineEx::doGetSWRunInfo(IEspContext& context, CMachineInfoThreadParam
                                    bool bMonitorDaliFileServer,
                                    const StringArray& additionalProcesses)
 {
-    map<string, StlLinked<IEspSWRunInfo> > processMap; //save only one description of each process
-   map<int, StlLinked<IEspSWRunInfo> > pidMap;
+    map<string, Linked<IEspSWRunInfo> > processMap; //save only one description of each process
+   map<int, Linked<IEspSWRunInfo> > pidMap;
     bool bLinuxInstance = pParam->m_operatingSystem == OS_Linux;
     bool bAddColumn = false;
 
@@ -1846,8 +1846,8 @@ void Cws_machineEx::doGetSWRunInfo(IEspContext& context, CMachineInfoThreadParam
                                             bFilterProcesses, &processMap, pidMap, NULL);
         }
 
-      map<string, StlLinked<IEspSWRunInfo> >::const_iterator it;
-      map<string, StlLinked<IEspSWRunInfo> >::const_iterator iEnd = processMap.end();
+      map<string, Linked<IEspSWRunInfo> >::const_iterator it;
+      map<string, Linked<IEspSWRunInfo> >::const_iterator iEnd = processMap.end();
 
         if (!m_useDefaultHPCCInit)
         {

--- a/esp/services/ws_machine/ws_machineService.hpp
+++ b/esp/services/ws_machine/ws_machineService.hpp
@@ -284,7 +284,7 @@ private:
         IArrayOf<IEspProcessInfo>& runningProcesses, const char* pszProcessType, bool bFilterProcesses, bool bMonitorDaliFileServer, const StringArray& additionalProcesses);
     const char* lookupProcessname(const StringBuffer& sProcessType);
     void enumerateRunningProcesses(CMachineInfoThreadParam* pParam, IArrayOf<IEspProcessInfo>& runningProcesses, bool bLinuxInstance,
-            bool bFilterProcesses, map<string, StlLinked<IEspSWRunInfo> >* processMap, map<int, StlLinked<IEspSWRunInfo> >& pidMap,
+            bool bFilterProcesses, map<string, Linked<IEspSWRunInfo> >* processMap, map<int, Linked<IEspSWRunInfo> >& pidMap,
                                                              set<string>* pRequiredProcesses);
     char* skipChar(const char* sBuf, char c);
     void readRunningProcess(const char* lineBuf, IArrayOf<IEspProcessInfo>& runningProcesses);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1697,7 +1697,7 @@ StringBuffer& WsWuSearch::createWuidFromDate(const char* timestamp,StringBuffer&
 struct CompareData
 {
     CompareData(const char* _filter): filter(_filter) {}
-    bool operator()(const StlLinked<DataCacheElement>& e) const
+    bool operator()(const Linked<DataCacheElement>& e) const
     {
         return stricmp(e->m_filter.c_str(),filter)==0;
     }
@@ -1719,7 +1719,7 @@ DataCacheElement* DataCache::lookup(IEspContext &context, const char* filter, un
     timeNow.adjustTime(-timeout);
     while (true)
     {
-        std::list<StlLinked<DataCacheElement> >::iterator list_iter = cache.begin();
+        std::list<Linked<DataCacheElement> >::iterator list_iter = cache.begin();
         if (list_iter == cache.end())
             break;
 
@@ -1734,7 +1734,7 @@ DataCacheElement* DataCache::lookup(IEspContext &context, const char* filter, un
         return NULL;
 
     //Check whether we have the data cache for this cluster. If yes, get the version
-    std::list<StlLinked<DataCacheElement> >::iterator it = std::find_if(cache.begin(),cache.end(),CompareData(filter));
+    std::list<Linked<DataCacheElement> >::iterator it = std::find_if(cache.begin(),cache.end(),CompareData(filter));
     if(it!=cache.end())
     {
         return it->getLink();
@@ -1764,7 +1764,7 @@ void DataCache::add(const char* filter, const char* data, const char* name, cons
 struct CompareArchivedWUs
 {
     CompareArchivedWUs(const char* _filter): filter(_filter) {}
-    bool operator()(const StlLinked<ArchivedWuCacheElement>& e) const
+    bool operator()(const Linked<ArchivedWuCacheElement>& e) const
     {
         return stricmp(e->m_filter.c_str(),filter)==0;
     }
@@ -1786,7 +1786,7 @@ ArchivedWuCacheElement* ArchivedWuCache::lookup(IEspContext &context, const char
     timeNow.adjustTime(-timeout);
     while (true)
     {
-        std::list<StlLinked<ArchivedWuCacheElement> >::iterator list_iter = cache.begin();
+        std::list<Linked<ArchivedWuCacheElement> >::iterator list_iter = cache.begin();
         if (list_iter == cache.end())
             break;
 
@@ -1801,7 +1801,7 @@ ArchivedWuCacheElement* ArchivedWuCache::lookup(IEspContext &context, const char
         return NULL;
 
     //Check whether we have the data cache for this cluster. If yes, get the version
-    std::list<StlLinked<ArchivedWuCacheElement> >::iterator it = std::find_if(cache.begin(),cache.end(),CompareArchivedWUs(filter));
+    std::list<Linked<ArchivedWuCacheElement> >::iterator it = std::find_if(cache.begin(),cache.end(),CompareArchivedWUs(filter));
     if(it!=cache.end())
         return it->getLink();
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -244,7 +244,7 @@ struct DataCache: public CInterface, implements IInterface
     void add(const char* filter, const char* data, const char* name, const char* localName, const char* wuid,
     const char* resultName, unsigned seq,   __int64 start, unsigned count, __int64 requested, __int64 total);
 
-    std::list<StlLinked<DataCacheElement> > cache;
+    std::list<Linked<DataCacheElement> > cache;
     CriticalSection crit;
     size32_t cacheSize;
 };
@@ -285,7 +285,7 @@ struct ArchivedWuCache: public CInterface, implements IInterface
 
     void add(const char* filter, const char* sashaUpdatedWhen, bool hasNextPage, IArrayOf<IEspECLWorkunit>& wus);
 
-    std::list<StlLinked<ArchivedWuCacheElement> > cache;
+    std::list<Linked<ArchivedWuCacheElement> > cache;
     CriticalSection crit;
     size32_t cacheSize;
 };

--- a/services/winremote/winremote.cpp
+++ b/services/winremote/winremote.cpp
@@ -319,7 +319,7 @@ protected:
     };
 };
 
-//typedef WaitQueue<StlLinked<ServiceTask> > ConnectQueueType;
+//typedef WaitQueue<Linked<ServiceTask> > ConnectQueueType;
 
 
 struct RemoteCommand: public CInterface, implements IRemoteCommand

--- a/system/jlib/jpqueue.hpp
+++ b/system/jlib/jpqueue.hpp
@@ -256,7 +256,7 @@ private:
     }
 
  
-    WaitQueue<StlLinked<ITask> > queue;
+    WaitQueue<Linked<ITask> > queue;
 
     size32_t maxsize;
     friend class WorkerThread;

--- a/system/security/shared/SecurityResourceList.hpp
+++ b/system/security/shared/SecurityResourceList.hpp
@@ -32,7 +32,7 @@ private:
     bool m_complete;
     StringAttr m_name;
     IArrayOf<ISecResource> m_rlist;
-    std::map<std::string, StlLinked<ISecResource> > m_rmap;  
+    std::map<std::string, Linked<ISecResource> > m_rmap;
 
 public:
     IMPLEMENT_IINTERFACE


### PR DESCRIPTION
This change is designed to make it easier to understand the smart
pointer objects used to support the link release model.  I have
created a new Shared<> template class which is the base class for the
Owned<> and Linked<> classes.
The Shared<> class is similar to a boost intrusive_ptr, and is an STL
compatible object which holds a reference to a linked object or
interface.  You can pass and return Shared objects, and not need to
ever call Link/Release/set/setown.

However Shared contains no methods for constructing a Shared from a
pointer, or assigning a pointer to a Shared.  This needs to be done
explicitly using the Linked and Owned clasess.  This means that it
is explicit whether you are taking ownership of the object or not.
(Boost uses an extra parameter which may reduce link/releases in a few
situations, but is much less clear).

Any function that takes a reference to a smart pointer - so it can be
updated in place, should use a type Shared<x>.

There are also a couple of template functions OWNED and LINKED which
are short cuts for creating an Owned/Linked object.  E.g.,
void myFunction(Shared<CLASS> x);
myFunction(OWNED(myPointer));
I'm not so sure they are a good idea - please debate.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
