### PR TITLE
Fix gh-753 ensure the global workunit is available

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -5288,9 +5288,8 @@ IConstWUResult* CLocalWorkUnit::getGlobalByName(const char *qname) const
     CriticalBlock block(crit);
     if (strcmp(p->queryName(), GLOBAL_WORKUNIT)==0)
         return getVariableByName(qname);
-    Owned <IConstWorkUnit> global = factory->openWorkUnit(GLOBAL_WORKUNIT, false);
-    if (!global)
-        global.setown(factory->createWorkUnit(NULL, NULL, NULL));
+
+    Owned <IWorkUnit> global = factory->ensureNamedWorkUnit(GLOBAL_WORKUNIT);
     return global->getVariableByName(qname);
 }
 


### PR DESCRIPTION
- Previously getGlobalByName() created a dummy workunit if global wu
  did not exist it should always use the global one instead.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
